### PR TITLE
Parse 'encrypted' entry in collabs

### DIFF
--- a/vantage6/server/controller/fixture.py
+++ b/vantage6/server/controller/fixture.py
@@ -38,7 +38,7 @@ def load(fixtures, drop_all=False):
     for col in fixtures.get("collaborations", {}):
 
         # create collaboration
-        collaboration = db.Collaboration(name=col.get("name"))
+        collaboration = db.Collaboration(name=col.get("name"), encrypted=col.get("encrypted", True))
         log.debug(f"processed collaboration={collaboration.name}")
 
         # append organizations to the collaboration


### PR DESCRIPTION
Enables encryption to be enabled/disabled in an entities YAML. Still sets it to True by default, so will not change outcomes for any existing YAMLs out there.