### PR TITLE
Prevent users from changing their own permissions

### DIFF
--- a/vantage6/server/resource/role.py
+++ b/vantage6/server/resource/role.py
@@ -227,10 +227,6 @@ class Role(ServicesResources):
             return {"msg": f"Role with id={id} not found."}, \
                 HTTPStatus.NOT_FOUND
 
-        if role in g.user.roles:
-            return {'msg': 'You cannot delete your own roles!'}, \
-                HTTPStatus.UNAUTHORIZED
-
         if not self.r.d_glo.can():
             if not self.r.d_org.can():
                 return {'msg': 'You do not have permission to delete roles!'},\
@@ -318,10 +314,6 @@ class RoleRules(ServicesResources):
         if not rule:
             return {'msg': f'Rule id={rule_id} not found!'}, \
                 HTTPStatus.NOT_FOUND
-
-        if role in g.user.roles:
-            return {'msg': 'You cannot delete rules from your own roles!'}, \
-                HTTPStatus.UNAUTHORIZED
 
         if not self.r.d_glo.can():
             if not (self.r.d_org.can() and

--- a/vantage6/server/resource/role.py
+++ b/vantage6/server/resource/role.py
@@ -102,8 +102,8 @@ class Role(ServicesResources):
     def get(self, id=None):
         """View roles
 
-        Depending on permission, you can view nothing, your organization or all the
-        available roles at the server.
+        Depending on permission, you can view nothing, your organization or all
+        the available roles at the server.
         """
         if self.r.v_glo.can():
             # view all roles at the server
@@ -227,6 +227,10 @@ class Role(ServicesResources):
             return {"msg": f"Role with id={id} not found."}, \
                 HTTPStatus.NOT_FOUND
 
+        if role in g.user.roles:
+            return {'msg': 'You cannot delete your own roles!'}, \
+                HTTPStatus.UNAUTHORIZED
+
         if not self.r.d_glo.can():
             if not self.r.d_org.can():
                 return {'msg': 'You do not have permission to delete roles!'},\
@@ -314,6 +318,10 @@ class RoleRules(ServicesResources):
         if not rule:
             return {'msg': f'Rule id={rule_id} not found!'}, \
                 HTTPStatus.NOT_FOUND
+
+        if role in g.user.roles:
+            return {'msg': 'You cannot delete rules from your own roles!'}, \
+                HTTPStatus.UNAUTHORIZED
 
         if not self.r.d_glo.can():
             if not (self.r.d_org.can() and

--- a/vantage6/server/resource/user.py
+++ b/vantage6/server/resource/user.py
@@ -263,6 +263,11 @@ class User(ServicesResources):
                         HTTPStatus.NOT_FOUND
                 roles.append(role)
 
+            # validate that user is not changing their own roles
+            if user == g.user:
+                return {'msg': "You can't changes your own roles!"}, \
+                    HTTPStatus.UNAUTHORIZED
+
             # validate that user can assign these
             for role in roles:
                 denied = self.permissions.verify_user_rules(role.rules)
@@ -280,6 +285,11 @@ class User(ServicesResources):
                     return {'msg': f'Rule={rule_id} can not be found!'}, \
                         HTTPStatus.NOT_FOUND
                 rules.append(rule)
+
+            # validate that user is not changing their own rules
+            if user == g.user:
+                return {'msg': "You can't changes your own rules!"}, \
+                    HTTPStatus.UNAUTHORIZED
 
             # validate that user can assign these
             denied = self.permissions.verify_user_rules(rules)


### PR DESCRIPTION
As noted in Issue IKNL/vantage6-main#124, users are currently able to shrink their own permission space while this should not be the case. Therefore, several checks were added in this branch:
- in assigning roles or rules to a user via a patch request, this is no longer allowed by that user itself. This ensures users can neither shrink nor increase their permissions (increasing one's own permissions was already prevented by other checks as well) 
- deleting roles or deleting rules from a role can now no longer be done by a user that has this role