### PR TITLE
Ensuring that users can no longer be assigned to non-existent organizations by root

### DIFF
--- a/vantage6/server/resource/user.py
+++ b/vantage6/server/resource/user.py
@@ -167,7 +167,7 @@ class User(ServicesResources):
                     org = db.Organization.get(data['organization_id'])
                     if not org:
                         return {'msg': "Organization does not exist."}, \
-                            HTTPStatus.UNAUTHORIZED
+                            HTTPStatus.NOT_FOUND
                 else:  # not-root user cant create users for other organization
                     return {'msg': 'You lack the permission to do that!'}, \
                         HTTPStatus.UNAUTHORIZED
@@ -314,7 +314,7 @@ class User(ServicesResources):
                 org = db.Organization.get(data['organization_id'])
                 if not org:
                     return {'msg': 'Organization does not exist.'}, \
-                        HTTPStatus.UNAUTHORIZED
+                        HTTPStatus.NOT_FOUND
                 else:
                     log.warn(
                         f'Running as root and assigning (new) '


### PR DESCRIPTION
Introduced a check in both POST and PATCH request for /user that verifies that the organization id to which the user is assigned actually exists. While the original issue in IKNL/vantage6-main#132 was already fixed, this further extends that solution.