### PR TITLE
Removed permissions for creating and deleting port entries

### DIFF
--- a/vantage6/server/resource/port.py
+++ b/vantage6/server/resource/port.py
@@ -66,10 +66,6 @@ def permissions(permissions: PermissionManager):
     add(scope=S.ORGANIZATION, operation=P.VIEW, assign_to_container=True,
         assign_to_node=True, description="view ports of your organizations "
         "collaborations")
-    add(scope=S.ORGANIZATION, operation=P.CREATE, assign_to_node=True,
-        description="create algorithm port entries")
-    add(scope=S.ORGANIZATION, operation=P.DELETE, assign_to_node=True,
-        description="create algorithm port entries")
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Only nodes are allowed to do this, so there shouldn't be any rules that can be assigned to users as they will not be allowed to do this anyway