### PR TITLE
Fix organization patch request

### DIFF
--- a/vantage6/server/resource/organization.py
+++ b/vantage6/server/resource/organization.py
@@ -282,7 +282,7 @@ class Organization(OrganizationBase):
         fields = ["name", "address1", "address2", "zipcode", "country",
                   "public_key", "domain"]
         for field in fields:
-            if field in data:
+            if field in data and data[field] is not None:
                 setattr(organization, field, data[field])
 
         organization.save()


### PR DESCRIPTION
All fields in organzation patch were always updated, even if they were not defined. This is now prevented by a check on whether they are None.

Fix IKNL/vantage6-main#35